### PR TITLE
троеточие и полоска

### DIFF
--- a/src/partials/methods-section.html
+++ b/src/partials/methods-section.html
@@ -8,20 +8,20 @@
          </svg>
          <h3 class="card-title dash">Адаптированная программа
            подготовки к ВНО</h3>
-         <p class="text-methods">Ты будешь изучать грамматику и лексику одновременно. И ты научишься писать сочинения.</p>
+         <p class="text-methods clamp">Ты будешь изучать грамматику и лексику одновременно. И ты научишься писать сочинения. </p>
        </li>  <li class="list-item">
         <svg class="icon-methods" width="54" height="48">
            <use href="./images/svg/symbol-defs.svg#icon-smartphone"></use>
          </svg>
          <h3 class="card-title dash">Аудитория и онлайн-обучение</h3>
-         <p class="text-methods">Учитель поможет не только в аудитории, но и во время домашней подготовки.
+         <p class="text-methods clamp">Учитель поможет не только в аудитории, но и во время домашней подготовки.
            Родители могут участвовать в чате при желании.</p>
        </li>  <li class="list-item">
         <svg class="icon-methods" width="54" height="48">
           <use href="./images/svg/symbol-defs.svg#icon-book"></use>
          </svg>
          <h3 class="card-title dash">Привычка читать на английском языке</h3>
-         <p class="text-methods">Статьи из источников, которые используются при разработке настоящего ВНО, будут приходить на телефон дважды в неделю.
+         <p class="text-methods clamp">Статьи из источников, которые используются при разработке настоящего ВНО, будут приходить на телефон дважды в неделю.
  
          </p>
        </li>  <li class="list-item">
@@ -30,14 +30,14 @@
          </svg>
          <h3 class="card-title dash">Психологическая
            поддержка</h3>
-         <p class="text-methods">Мы научим тебя методикам прохождения тестирований, умению планировать свою подготовку уверенности 
+         <p class="text-methods clamp">Мы научим тебя методикам прохождения тестирований, умению планировать свою подготовку уверенности 
            в себе.</p>
        </li>  <li class="list-item">
          <svg class="icon-methods" width="54" height="48">
           <use href="./images/svg/symbol-defs.svg#icon-teacher"></use>
          </svg>
          <h3 class="card-title dash">Обучение по авторским пособиям</h3>
-         <p class="text-methods">Тебе не нужно тратить время 
+         <p class="text-methods clamp">Тебе не нужно тратить время 
            на  самостоятельный поиск материала и ничего покупать дополнительно. Мы составили 
            2 пособия для тебя.</p>
        </li>  <li class="list-item">
@@ -45,7 +45,7 @@
           <use href="./images/svg/symbol-defs.svg#icon-audio-book"></use>
          </svg>
          <h3 class="card-title dash">Умение воспринимать устную английскую речь</h3>
-         <p class="text-methods">“F.R.I.E.N.D.S” тебе не помогут. Ты будешь регулярно слушать 
+         <p class="text-methods clamp">“F.R.I.E.N.D.S” тебе не помогут. Ты будешь регулярно слушать 
            и разбирать аудиозаписи 
            в соответствии с изучаемой лексикой.</p>
        </li>

--- a/src/sass/components/_clamp.scss
+++ b/src/sass/components/_clamp.scss
@@ -1,0 +1,7 @@
+.clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: 5;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+
+}

--- a/src/sass/components/_dash.scss
+++ b/src/sass/components/_dash.scss
@@ -1,0 +1,9 @@
+.dash:after{
+    content: "";
+    position: absolute;
+    display: block;
+    width: 20px;
+    height: 2px;
+    background-color: $accent-color;
+   
+}

--- a/src/sass/layout/_methods-sectoin.scss
+++ b/src/sass/layout/_methods-sectoin.scss
@@ -75,7 +75,7 @@
         @include for-size(desktop){
             width: calc((100% - 10px * 6) / 3);
             height: 396px;
-            padding: 30px 40px;
+            padding: 30px 30px;
             margin: 10px;
         }
     }
@@ -120,43 +120,14 @@
         line-height: 1.40;
 
     }
-    &.dash::after{
-        content: "";
-        position: absolute;
-        display: block;
-        width: 20px;
-        height: 2px;
-        background-color: $accent-color;
+    &::after{
+        
         bottom: 0;
         left: 50%;
         transform: translateX(-50%);
     }
-    // &::after{
-    //     content: "";
-    //     position: absolute;
-    //     display: block;
-    //     width: 20px;
-    //     height: 2px;
-    //     background-color: $accent-color;
-    //     bottom: 0;
-    //     left: 50%;
-    //     transform: translateX(-50%);
-       
-       
-        
-    // }
+   
 }
-// .dash::after{
-//     content: "";
-//     position: absolute;
-//     display: block;
-//     width: 20px;
-//     height: 2px;
-//     background-color: $accent-color;
-//     bottom: 0;
-//     left: 50%;
-//     transform: translateX(-50%);
-// }
 .icon-methods{
     fill:$accent-color;
    
@@ -174,4 +145,5 @@
     line-height: 1.56;
 
     }
+    
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -5,6 +5,7 @@
 @import './components/logo';
 @import './components/button';
 @import "./components/dash";
+@import "./components/clamp";
 @import './layout/page-headr';
 @import './components/menu';
 @import './layout/section-hero';


### PR DESCRIPTION
.dash:after{
    content: "";
    position: absolute;
    display: block;
    width: 20px;
    height: 2px;
    background-color: $accent-color;
    bottom: 0;
    left: 50%;
   
добавлю класс .dash
для оранжевой полоски (без позиционирования, он будет для ::after или ::befor. положу в компоненты.  У кого полоска 20 пикселей, можете добавлять просто класс в хтмл,  а в цсс добавить нужное вам позиционирование через ::after или ::befor transform: translateX(-50%);
}


добавлю класс .clamp
для троеточие после текста, который не влез. В комментариях точно видела такое, может еще у кого есть
 
.clamp{
    display: -webkit-box;
    -webkit-line-clamp: 5;
    -webkit-box-orient: vertical;
    overflow: hidden;

}
